### PR TITLE
Fix and Apply Ptracker configs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import {
 } from "@openmrs/esm-framework";
 import { configSchema } from "./config-schema";
 import patientDashboardsConfig from "./namibia-esm-and-dashboards-config.json";
-import namibiaDashboardsConfig from "./namibia-config";
 
 require("./root.scss");
 
@@ -24,7 +23,10 @@ const options = {
 
 export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
-
   provide(patientDashboardsConfig);
-  // provide(namibiaDashboardsConfig);
 }
+
+export const mnchClinicalDashboard = getAsyncLifecycle(
+  () => import("./root"),
+  options
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,11 @@ import {
   getAsyncLifecycle,
   defineConfigSchema,
   provide,
+  getSyncLifecycle,
 } from "@openmrs/esm-framework";
 import { configSchema } from "./config-schema";
 import patientDashboardsConfig from "./namibia-esm-and-dashboards-config.json";
+import { ConfigIniz } from "./root";
 
 require("./root.scss");
 
@@ -30,3 +32,7 @@ export const mnchClinicalDashboard = getAsyncLifecycle(
   () => import("./root"),
   options
 );
+
+// There is a regression with how configs are being loaded by framework driven by supported routes.
+// This hack forces the framework to run this module's starter func on initial load
+export const configInitializer = getSyncLifecycle(ConfigIniz, options);

--- a/src/namibia-esm-and-dashboards-config.json
+++ b/src/namibia-esm-and-dashboards-config.json
@@ -41,7 +41,8 @@
         "remove":[
             "appointments-ohri-dashboard-ext",
             "dispensing-ohri-dashboard-ext",
-            "service-queues-ohri-dashboard-ext"
+            "service-queues-ohri-dashboard-ext",
+            "home-dashboard-ext"
         ]
       }
     }

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -13,3 +13,7 @@ export default function Root() {
     </BrowserRouter>
   );
 }
+
+export function ConfigInitializer() {
+  return <></>;
+}

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+
+export default function Root() {
+  return (
+    <BrowserRouter basename={window['getOpenmrsSpaBase']()}>
+      <Routes>
+        <Route path="/home" element={<Navigate to={'/dashboard/mother-child-health'} replace />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import React from "react";
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 
 export default function Root() {
   return (
-    <BrowserRouter basename={window['getOpenmrsSpaBase']()}>
+    <BrowserRouter basename={window["getOpenmrsSpaBase"]()}>
       <Routes>
-        <Route path="/home" element={<Navigate to={'/dashboard/mother-child-health'} replace />} />
+        <Route
+          path="/home"
+          element={<Navigate to={"/dashboard/mother-child-health"} replace />}
+        />
       </Routes>
     </BrowserRouter>
   );

--- a/src/routes.json
+++ b/src/routes.json
@@ -5,9 +5,15 @@
     },
     "pages": [
       {
-        "component": "dashboard",
+        "component": "mnchClinicalDashboard",
         "route": "home"
-      }
+      },
+      {
+        "component": "configInitializer",
+        "route": true,
+        "online": true,
+        "offline": true
+      } 
     ],
     "extensions": []
   }

--- a/src/routes.json
+++ b/src/routes.json
@@ -3,6 +3,11 @@
     "backendDependencies": {
       "webservices.rest": "^2.24.0"
     },
-    "pages": [],
+    "pages": [
+      {
+        "component": "dashboard",
+        "route": "home"
+      }
+    ],
     "extensions": []
   }


### PR DESCRIPTION
This work has been done in collaboration with @ODORA0 and fixes the below:
- Removes the home DB and other none pTracker DBs from the Clinical board (OHRI-1527)
- Applies Registration config
  - Next of Kin section (OHRI-1609)
  - Patients Identifiers. Note: The remaining bit for the Ptracker number to show is attributable to the backend config
- Remove all none Ptracker related dashboards from the Patient chart (OHRI-1603)

**Demo**:

![2023-07-07 19-28-10 2023-07-07 19_33_27](https://github.com/UCSF-IGHS/esm-namibia-emr/assets/26084581/8ee3c377-01e7-47bd-bfc1-b726a3379af4)



**Known issues**:

The patient chart seems to have some kind of regression. As you see in the demo, the banner and the configs are unstable. (See how the left nav items disappear)

![2023-07-07 19-35-34 2023-07-07 19_38_02](https://github.com/UCSF-IGHS/esm-namibia-emr/assets/26084581/aaad6f3e-a75b-4bf0-bc82-5e9fb9e9119a)

